### PR TITLE
Update README.md removing hyphen from "wake word" + mention openWakeWord

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
 ![banner_wwc](https://github.com/fwartner/home-assistant-wakewords-collection/assets/6692500/afa694ab-7329-4a13-a83c-e8f94ca3bcb0)
 
-# Home Assistant Wake-Word Collection
+# Home Assistant Wake Word Collection
 
-Welcome to the community-driven collection of wake-words for Home Assistant!
+Welcome to the community-driven collection of wake words for Home Assistant using [openWakeWord](https://github.com/dscripka/openWakeWord) wake word detection system!
 
 ## Easy Install
 Check out [WakeWords Installer](https://github.com/fwartner/ha-openwakeword-installer)!
 
 ## Usage Guidelines
-To incorporate any of the wake-words into your Home Assistant setup, please refer to the step-by-step instructions available in the [Home Assistant documentation](https://www.home-assistant.io/voice_control/create_wake_word/?ref=wartner.io#to-add-your-personal-wake-word-to-home-assistant).
+To incorporate any of the wake words into your Home Assistant setup, please refer to the step-by-step instructions available in the [Home Assistant documentation](https://www.home-assistant.io/voice_control/create_wake_word/?ref=wartner.io#to-add-your-personal-wake-word-to-home-assistant).
 
 ## Contribution Instructions
-If you'd like to contribute your own wake-words, simply follow the provided [instructions](https://www.home-assistant.io/voice_control/create_wake_word/) to train new wake-word models using Colab.
+If you'd like to contribute your own wake words, simply follow the provided [instructions](https://www.home-assistant.io/voice_control/create_wake_word/) to train new wake word models using Colab.
 
 ## Security Concerns
 For any security-related concerns, please reach out to me via email at florian@wartner.io, and I will address them promptly.


### PR DESCRIPTION
Update README.md removing hyphen from "wake word" (for proper grammar) + mention openWakeWord library that this is for.

Should maybe also add note that this collection currently only contain openWakeWord and not microWakeWord wake words?

As well mention that openWakeWord models are not compatible with microWakeWord models or vice versa?

* https://github.com/dscripka/openWakeWord

* https://github.com/kahrendt/microWakeWord

PS: microWakeWord will probably become popular within Home Assistant once their voice-kit hardware is released later this year:

- https://www.reddit.com/r/homeassistant/comments/1g460ha/when_will_the_hanabu_voice_kit_be_revealed/

- https://www.home-assistant.io/blog/2024/06/12/roadmap-2024h1#voice-assistants